### PR TITLE
fix: bug #3, HP update on overburdened state

### DIFF
--- a/app/static/src/js/inventoryUI.js
+++ b/app/static/src/js/inventoryUI.js
@@ -334,6 +334,31 @@ const inventoryUI = {
 
     // Set the container headers
     this.setContainerHeaders(container);
+
+    // Update HP data, if we are on edit page.
+    // It is possible to restore old HP during inventory updates,
+    // but only until we save the form.
+    // To be able to restore HP every time, we need either a global JS app state
+    // or backend storage during edit.
+    const hpInput = document.getElementById("hp-input");
+    const hpInputMax = document.getElementById("hp-max-input");
+    const overBurdened = hpInput && hpInputMax && inventory.getSlotsCount(0) >= 10 && !this.storedHP;
+    const clearOverBurdened = hpInput && hpInputMax && inventory.getSlotsCount(0) < 10 && this.storedHP;
+    if (overBurdened) {
+      hpInput.classList.add("red-text");
+      this.storedHP = hpInput.value;
+      hpInput.value = 0;
+      hpInputMax.classList.add("red-text");
+    }
+    // Separate case because we are checking also editing state 
+    // and DOM elements existence in the same condition.
+    if (clearOverBurdened) {
+      hpInput.classList.remove("red-text");
+      hpInput.value = this.storedHP ? this.storedHP : hpInput.value;
+      this.storedHP = null;
+      hpInputMax.classList.remove("red-text");
+    }
+
   },
 
   showSaveFooter() {


### PR DESCRIPTION
Closes #3 

Fixed HP update when updating inventory.
Current app structure allows for HP restore, but only until form is saved.