### PR TITLE
Update Webmanifest Name

### DIFF
--- a/app/static/icons/site.webmanifest
+++ b/app/static/icons/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "MyWebSite",
-  "short_name": "MySite",
+  "name": "Kettlewright",
+  "short_name": "Kettlewright",
   "icons": [
     {
       "src": "/web-app-manifest-192x192.png",


### PR DESCRIPTION
The name and shortname in `site.webmanifest` are boilerplate values. When the site is "installed", it shows this value. This change updates them to match the actual site name.