### PR TITLE
Use relative URL for character copy button

### DIFF
--- a/app/static/src/js/characters.js
+++ b/app/static/src/js/characters.js
@@ -8,7 +8,8 @@ const redirectToCharacterPage = (element) => {
 const copyLink = (element) => {
   const urlName = element.dataset.urlName;
   const ownerUsername = element.dataset.ownerUsername;
-  const link = `https://kettlewright.cairnrpg.com/users/${ownerUsername}/characters/${urlName}/`;
+  const base = window.location.origin;
+  const link = `${base}/users/${ownerUsername}/characters/${urlName}/`;
   navigator.clipboard.writeText(link);
 }
 


### PR DESCRIPTION
I found this hardcoded instance of the upstream hosting URL. Note, that I am not a webdev, so I do not know whether this is the correct way to fix this. Take this as a suggestion please.