### PR TITLE
fix: add missing auth.py logic for account deletion

### DIFF
--- a/app/blueprints/auth.py
+++ b/app/blueprints/auth.py
@@ -5,7 +5,7 @@ from flask import Blueprint, render_template, redirect, url_for, request, flash,
 from markupsafe import Markup
 from flask_login import login_user, login_required, logout_user, current_user
 from app.models import db, User
-from app.forms import LoginForm, RegistrationForm, PasswordResetRequestForm, PasswordResetForm, ResendConfirmationForm, PasswordUpdateForm, EmailUpdateForm
+from app.forms import LoginForm, RegistrationForm, PasswordResetRequestForm, PasswordResetForm, ResendConfirmationForm, PasswordUpdateForm, EmailUpdateForm, DeleteAccountForm
 from app.email import send_email
 import os
 from flask_babel import _
@@ -265,6 +265,30 @@ def change_email():
                 flash(error, 'error')
 
     return render_template('auth/change_email.html', form=form)
+
+@auth.route('/delete_account', methods=['GET', 'POST'])
+@login_required
+def delete_account():
+    form = DeleteAccountForm()
+    
+    if form.validate_on_submit():
+        password = form.password.data
+        
+        if current_user.verify_password(password):
+            user_id = current_user.id
+            logout_user()
+            
+            user_to_delete = User.query.get(user_id)
+            db.session.delete(user_to_delete)
+            db.session.commit()
+            
+            flash('Your account has been successfully deleted.', 'success')
+            return redirect(url_for('main.index'))
+        else:
+            flash('Invalid password. Account deletion cancelled.', 'error')
+            return redirect(url_for('auth.delete_account'))
+    
+    return render_template('auth/delete_account.html', form=form)
 
 
 # ________________ CAPTCHA STUFF __________________________________


### PR DESCRIPTION
I apologize for the BuildError. I previously missed including the auth.py file in the commit, which contains the delete_account route definition. Since the template was trying to reference a route that hadn't been registered yet, the url_for function failed. I've just pushed the missing file, which should resolve the CI failure.