### PR TITLE
Hide bonds section in print view when empty

### DIFF
--- a/app/templates/main/character_print.html
+++ b/app/templates/main/character_print.html
@@ -84,6 +84,7 @@
         </div>
       </div>
       {% endif %}
+      {% if character.bonds != "" %}
       <div id="character-print-bonds-container" class="print-container">
         <div class="character-section">
           <h3>{{_('Bonds')}}</h3>
@@ -91,6 +92,7 @@
           <p id="character-bonds-view" class="with-whitespace">{{character.bonds}}</p>
         </div>
       </div>
+      {% endif %}
       {% if character.omens != "" %}
       <div id="character-print-omens-container" class="print-container">
         <div class="character-section">

--- a/tests/unit/bonds/test_json_export_and_printing.py
+++ b/tests/unit/bonds/test_json_export_and_printing.py
@@ -35,3 +35,21 @@ def test_fieldwarden_print_rendering_includes_both_bonds(app_with_babel):
             
             assert 'id="character-bonds-view"' in html
             assert 'class="with-whitespace"' in html
+
+
+def test_empty_bonds_hidden_in_print_view(app_with_babel):
+    """Bonds container should not render when bonds field is empty."""
+    with app_with_babel.test_client() as client:
+        with app_with_babel.app_context():
+            _, json_data = generate_character("Aurifex")
+            data = json.loads(json_data)
+            data['bonds'] = ""
+
+            response = client.post('/gen/character/print',
+                                   data={'json_data': json.dumps(data)},
+                                   follow_redirects=True)
+
+            assert response.status_code == 200
+            html = response.data.decode('utf-8')
+
+            assert 'id="character-print-bonds-container"' not in html


### PR DESCRIPTION
Bonds was always rendering in the print view even when the field was empty. Omens, description, and scars all already have an `{% if %}` guard around them — bonds was just missing one.

One-line fix to match the existing pattern.